### PR TITLE
Fix handling of DHCPv6 replies containing unrequested IA_NA/IA_PD options

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -947,6 +947,10 @@ static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
 				&& olen > -4 + sizeof(struct dhcpv6_ia_hdr)) {
 			struct dhcpv6_ia_hdr *ia_hdr = (void*)(&odata[-4]);
 
+			if ((na_mode == IA_MODE_NONE && otype == DHCPV6_OPT_IA_NA) ||
+			    (pd_mode == IA_MODE_NONE && otype == DHCPV6_OPT_IA_PD))
+				continue;
+
 			// Test ID
 			if (ia_hdr->iaid != htonl(1) && otype == DHCPV6_OPT_IA_NA)
 				continue;


### PR DESCRIPTION
Some DHCPv6 server could send replies with IA_NA/IA_PD error statuses even if no IA_NA/IA_PD were requested in preceeding request packets. Next, odhcp6c treats them as real error and skips reply even if it contains valid other IA (either IA_NA or IA_PD) option.
This patch skips handling of IA if it wasn't tried/forced at all.