### PR TITLE
Avoid of waiting for Advertise in stateless-only mode

### DIFF
--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -278,13 +278,14 @@ int main(_unused int argc, char* const argv[])
 		odhcp6c_clear_state(STATE_NTP_FQDN);
 		odhcp6c_clear_state(STATE_SIP_IP);
 		odhcp6c_clear_state(STATE_SIP_FQDN);
-		dhcpv6_set_ia_mode(ia_na_mode, ia_pd_mode);
 		bound = false;
 
 		syslog(LOG_NOTICE, "(re)starting transaction on %s", ifname);
 
 		signal_usr1 = signal_usr2 = false;
-		int mode = dhcpv6_request(DHCPV6_MSG_SOLICIT);
+		int mode = dhcpv6_set_ia_mode(ia_na_mode, ia_pd_mode);
+		if (mode != DHCPV6_STATELESS)
+			mode = dhcpv6_request(DHCPV6_MSG_SOLICIT);
 		odhcp6c_signal_process();
 
 		if (mode < 0)

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -308,7 +308,7 @@ struct odhcp6c_request_prefix {
 };
 
 int init_dhcpv6(const char *ifname, unsigned int client_options, int sol_timeout);
-void dhcpv6_set_ia_mode(enum odhcp6c_ia_mode na, enum odhcp6c_ia_mode pd);
+int dhcpv6_set_ia_mode(enum odhcp6c_ia_mode na, enum odhcp6c_ia_mode pd);
 int dhcpv6_request(enum dhcpv6_msg type);
 int dhcpv6_poll_reconfigure(void);
 int dhcpv6_promote_server_cand(void);


### PR DESCRIPTION
Start with Information-request when configured not to ask
IA_NA/IA_PD. It allows to complete the exchange using only
two messages, instead of four, and fixes infinite Advertise
waiting loop with servers that just ignore Solicit messages.