### PR TITLE
Alignment cleanups

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -586,12 +586,14 @@ int dhcpv6_request(enum dhcpv6_msg type)
 		for (; len < 0 && (round_start < round_end);
 				round_start = odhcp6c_get_milli_time()) {
 			uint8_t buf[1536];
-			uint8_t cmsg_buf[CMSG_SPACE(sizeof(struct in6_pktinfo))]
-				__aligned(__alignof__(struct cmsghdr));
+			union {
+				struct cmsghdr hdr;
+				uint8_t buf[CMSG_SPACE(sizeof(struct in6_pktinfo))];
+			} cmsg_buf;
 			struct iovec iov = {buf, sizeof(buf)};
 			struct sockaddr_in6 addr;
 			struct msghdr msg = {.msg_name = &addr, .msg_namelen = sizeof(addr),
-					.msg_iov = &iov, .msg_iovlen = 1, .msg_control = cmsg_buf,
+					.msg_iov = &iov, .msg_iovlen = 1, .msg_control = cmsg_buf.buf,
 					.msg_controllen = sizeof(cmsg_buf)};
 			struct in6_pktinfo *pktinfo = NULL;
 

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -18,7 +18,7 @@
 
 #define _unused __attribute__((unused))
 #define _packed __attribute__((packed))
-#define __aligned(n) __attribute__((aligned(n)))
+#define _aligned(n) __attribute__((aligned(n)))
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 

--- a/src/ra.c
+++ b/src/ra.c
@@ -275,7 +275,10 @@ bool ra_process(void)
 	bool found = false;
 	bool changed = false;
 	uint8_t buf[1500] __aligned(4);
-	uint8_t cmsg_buf[128] __aligned(__alignof__(struct cmsghdr));
+	union {
+		struct cmsghdr hdr;
+		uint8_t buf[CMSG_SPACE(sizeof(int))];
+	} cmsg_buf;
 	struct nd_router_advert *adv = (struct nd_router_advert*)buf;
 	struct odhcp6c_entry *entry = alloca(sizeof(*entry) + 256);
 	const struct in6_addr any = IN6ADDR_ANY_INIT;
@@ -302,7 +305,7 @@ bool ra_process(void)
 			.msg_namelen = sizeof(from),
 			.msg_iov = &iov,
 			.msg_iovlen = 1,
-			.msg_control = cmsg_buf,
+			.msg_control = cmsg_buf.buf,
 			.msg_controllen = sizeof(cmsg_buf),
 			.msg_flags = 0
 		};

--- a/src/ra.c
+++ b/src/ra.c
@@ -274,7 +274,7 @@ bool ra_process(void)
 {
 	bool found = false;
 	bool changed = false;
-	uint8_t buf[1500] __aligned(4);
+	uint8_t buf[1500] _aligned(4);
 	union {
 		struct cmsghdr hdr;
 		uint8_t buf[CMSG_SPACE(sizeof(int))];


### PR DESCRIPTION
This minor branch commits use more commonly used way for alignment of cmsg_buf, fixes the cmsg_buf size and syncs the macro style